### PR TITLE
Update layout.test to check Inter class

### DIFF
--- a/tests/app/layout.test.tsx
+++ b/tests/app/layout.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import RootLayout, { metadata } from '@/app/layout'
+import { Inter } from 'next/font/google'
+
+const inter = Inter({ subsets: ['latin'] })
 
 // Mock the Providers component
 jest.mock('@/components/providers', () => ({
@@ -42,7 +45,7 @@ describe('RootLayout', () => {
     )
 
     const bodyElement = container.querySelector('body')
-    expect(bodyElement).toHaveClass()
+    expect(bodyElement).toHaveClass(inter.className)
   })
 })
 


### PR DESCRIPTION
## Summary
- import and instantiate Inter font in `tests/app/layout.test.tsx`
- verify `<body>` gets the font class

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff5da0c8483308ad782616d204d05