### PR TITLE
Fix typo in sample seed

### DIFF
--- a/database/seeds/001_sample_data.sql
+++ b/database/seeds/001_sample_data.sql
@@ -887,7 +887,7 @@ INSERT INTO pipeline_cards (
     NULL,
     '323e4567-e89b-12d3-a456-426614174000', -- Direito Civil
     'Empresário - Cobrança Judicial',
-    'Empresário achOU o preço alto para cobrança de R$ 5.000',
+    'Empresário achou o preço alto para cobrança de R$ 5.000',
     2500.00,
     0.00,
     NULL,


### PR DESCRIPTION
## Summary
- correct `achOU` typo in seed data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff6566c54833092e873d2ba6657d6